### PR TITLE
Fixes for development mode

### DIFF
--- a/config/config.test.js
+++ b/config/config.test.js
@@ -11,16 +11,14 @@
  * @property {object} registryUrl.addTask  - url for pushTask to registry
  */
 module.exports = {
-  quantTime: 60000,
+  quantTime: 5000,
   baseHost: 'localhost',
   testhookUrl: 'https://notify.bot.ifmo.su/u/DDO5JQTW',
   apiUrl: {
-    index: 'https://api.monitor.ifmo.su',
-    getAll: 'https://api.monitor.ifmo.su' || 'http://localhost:8080/api/getAll.json',
+    getAll: 'https://api.monitor.ifmo.su/' || 'http://localhost:8080/api/getAll.json',
     postResult: '' || 'http://localhost:8080/api/postResult.json'
   },
   registryUrl: {
-    index: 'https://registry.ifmo.su',
     getTask: 'https://registry.ifmo.su/api/popTask/' || 'http://localhost:8080/registry/getTask.json',
     addTask: 'https://registry.ifmo.su/api/pushTask/' || 'http://localhost:8080/registry/postTask.json'
   }

--- a/config/index.js
+++ b/config/index.js
@@ -2,6 +2,8 @@ let config;
 
 if (process.env.NODE_ENV == 'production') {
   config = require('./config.prod');
+} else if (process.env.NODE_ENV == 'test') {
+  config = require('./config.test');
 } else {
   config = require('./config.local');
 }

--- a/data/api/getAll.json
+++ b/data/api/getAll.json
@@ -1,15 +1,19 @@
-[
-  {
-    "_id": "1",
-    "name": "Project name",
-    "url": "http://www.ifmo.ru/ru/",
-    "delay": 4000,
-    "lastPing": "2018-11-13T09:07:58.899Z",
-    "options": {
-      "statusContent": -1,
-      "sizeContent": -1,
-      "delayContent": -1
-    },
-    "notifications": []
+{
+  "data": {
+    "projects": [
+      {
+        "_id": "1",
+        "name": "Project name",
+        "url": "http://www.ifmo.ru/ru/",
+        "delay": 4000,
+        "lastPing": "2018-11-13T09:07:58.899Z",
+        "options": {
+          "statusContent": -1,
+          "sizeContent": -1,
+          "delayContent": -1
+        },
+        "notifications": []
+      }
+    ]
   }
-]
+}

--- a/data/registry/getTask.json
+++ b/data/registry/getTask.json
@@ -1,6 +1,6 @@
 {
   "_id": "1",
-  "url": "http://www.ifmo.ru/ru/",
+  "url": "http://exapmle.com/ok",
   "delay": 4000,
   "lastPing": "2018-11-13T09:07:58.899Z",
   "options": {
@@ -13,5 +13,6 @@
     "sizeContent": 10000,
     "delayContent": 50
   },
-  "notifications": []
+  "notifications": [],
+  "type": "api"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,6 +187,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -384,6 +390,12 @@
         }
       }
     },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
     "buffer-more-ints": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-0.0.2.tgz",
@@ -458,6 +470,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -473,6 +499,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -609,6 +641,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -703,6 +741,15 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -790,6 +837,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "director": {
       "version": "1.2.7",
@@ -1877,6 +1930,12 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -1992,6 +2051,12 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2074,6 +2139,12 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -2699,6 +2770,59 @@
         }
       }
     },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2792,6 +2916,40 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-10.0.2.tgz",
+      "integrity": "sha512-uWrdlRzG28SXM5yqYsUHfYBRqljF8P6aTRDh6Y5kTgs/Q4GB59QWlpiegmDHQouvmX/rDyKkC/nk+k4nA+QPNw==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^4.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
     },
     "node-static": {
       "version": "0.7.11",
@@ -3489,6 +3647,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pause-stream": {
       "version": "0.0.11",
       "resolved": "http://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
@@ -3609,6 +3773,12 @@
         "utile": "0.2.x",
         "winston": "0.8.x"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "ps-tree": {
       "version": "0.0.3",
@@ -4763,6 +4933,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "undefsafe": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,11 @@
     "request-promise": "^4.2.2"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
     "eslint": "^5.8.0",
     "eslint-config-codex": "github:codex-team/eslint-config",
+    "mocha": "^5.2.0",
+    "nock": "^10.0.2",
     "node-static": "^0.7.11",
     "nodemon": "^1.18.6"
   }

--- a/workers/base-worker.js
+++ b/workers/base-worker.js
@@ -8,6 +8,65 @@ const crypto = require('crypto');
 let config = require('../config');
 
 /**
+ *  START STUB for api-server, registry-server, notify-endpoint in dev mode
+ */
+
+if (process.env.NODE_ENV == 'development') {
+  const nock = require('nock');
+  let stubData = require('../data/api/getAll.json');
+  let stubTask = require('../data/registry/getTask.json');
+  let utils = require('../utils');
+
+  nock(config.apiUrl.index)
+    .log(console.log)
+    .persist()
+    // @todo postResult to api(notify)
+    .post('/', { query: utils.getSchema('queries/GetAllProjects.graphql') })
+    .delayBody(1000)
+    .reply(200, stubData);
+
+  nock(config.registryUrl.index)
+    .log(console.log)
+    .persist()
+    .get('/api/popTask/RequestWorker')
+    .delayBody(1000)
+    .reply(200, { task: stubTask })
+    .get('/api/popTask/ResponseWorker')
+    .delayBody(1000)
+    .reply(200, { task: stubTask })
+    .get('/api/popTask/NotifyWorker')
+    .delayBody(1000)
+    .reply(200, { task: stubTask })
+    .filteringRequestBody(function (body) {
+      return '*';
+    })
+    .put(/api\/pushTask\/.*/, '*')
+    .delayBody(1000)
+    .reply(200, 'put success');
+
+  nock('http://exapmle.com')
+    .persist()
+    .get('/ok')
+    .reply(200, 'Succes Result')
+    .get('/bad')
+    .reply(502);
+
+  nock(config.testhookUrl)
+    .log(console.log)
+    .persist()
+    .filteringRequestBody(function (body) {
+      return '*';
+    })
+    .post('', '*')
+    .delayBody(1000)
+    .reply(200);
+}
+
+/**
+ *  END STUB
+ */
+
+/**
  *  Class repesentation a BaseWorker
  *  @class BaseWorker
  *  @abstract


### PR DESCRIPTION
1. воркеры зависят от проектов апи и регистри. static сервер, который до этого использовался для локальной отладки(иммитации апи и регистри) перестал удовлетворять потребности. решил прикрутить для development mode вот такую вещь, которая гибко позволяет настраивать заглушки для http запросов. Сомневаюсь, что это "best practice", и что я подключил все грамотно, но кмк для локальной разработки это надо.
1.  в этом PR нет никаких тестов